### PR TITLE
Add inspect linkages test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ test:
         - cell_tree2d
     commands:
         - py.test --pyargs cell_tree2d
+        - conda inspect linkages -n _test cell_tree2d  # [linux]
 
 about:
     home: https://github.com/NOAA-ORR-ERD/cell_tree2d


### PR DESCRIPTION
Ideally we should always run this test when there is a `cython` extension.
